### PR TITLE
Add cached session

### DIFF
--- a/maproxy/cachedsession.py
+++ b/maproxy/cachedsession.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+import logging
+import socket
+import time
+
+import tornado
+
+import maproxy.proxyserver
+import maproxy.session
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+Session = maproxy.session.Session
+LoggerOptions = Session.LoggerOptions
+
+CACHE_KEY_NAME = "cache_key_name"
+
+
+class CacheSimulator(dict):
+    EXPIRATION_IN_SECONDS = 60
+
+    def set(self, key, data):
+        """Write to cache key+data
+
+        :param key: key to store
+        :param data: data to store
+        """
+        logger.debug("Cache: soring key '{}'".format(key))
+        self[key] = {
+            "key": key,
+            "timestamp": time.time(),
+            "data": data
+        }
+
+    def get(self, key):
+        """Read item from cache
+
+        :param key:key to retrieve
+        :return: data (or None if not found)
+        """
+        entry = super().get(key)
+        if not entry:
+            # item not found in cache
+            logger.debug("Cache: key '{}' not found".format(key))
+            return None
+
+        timestamp = entry["timestamp"]
+        if time.time() - timestamp > CacheSimulator.EXPIRATION_IN_SECONDS:
+            # Item expired. remove from cache
+            logger.debug("Cache: key '{}' expired".format(key))
+            del self[key]
+            return None
+
+        logger.debug("Cache: key '{}' found".format(key))
+        return entry["data"]
+
+
+g_cache = CacheSimulator()
+
+
+class CachedSession(Session):
+    """Extends the Session with cache
+
+    When we get a new connection - if we have "cached data" - return the cached
+    data (and don't even bother opening a socket to the server).
+
+    If we don't have cached data - operate just like standard session however
+    keep the data from the server in a cache. Note that we're storing in the
+    cache only when the connection is closed (to avoid partial data) !!!!
+    """
+
+    # def new_connection(self,stream : tornado.iostream.IOStream ,address,proxy):
+    def new_connection(self, stream, address, proxy):
+        # First,validation
+        assert isinstance(proxy, maproxy.proxyserver.ProxyServer)
+        assert isinstance(stream, tornado.iostream.IOStream)
+
+        # Logging
+        self.logger_nesting_level = 0  # logger_nesting_level is the current "nesting level"
+        if Session.LoggerOptions.LOG_NEW_SESSION_OP:
+            self.log("New Session")
+
+        # Remember our "parent" ProxyServer
+        self.proxy = proxy
+
+        # R/W flags for each socket
+        # Using the flags, we can tell if we're waiting for I/O completion
+        # NOTE: the "c2p" and "p2s" prefixes are NOT the direction of the IO,
+        #       they represent the SOCKETS :
+        #       c2p means the socket from the client to the proxy
+        #       p2s means the socket from the proxy to the server
+        self.c2p_reading = False  # whether we're reading from the client
+        self.c2p_writing = False  # whether we're writing to the client
+        self.p2s_writing = False  # whether we're writing to the server
+        self.p2s_reading = False  # whether we're reading from the server
+
+        # Init the Client->Proxy stream
+        self.c2p_stream = stream
+        self.c2p_address = address
+        # Client->Proxy  is connected
+        self.c2p_state = Session.State.CONNECTED
+
+        # Here we will put incoming data while we're still waiting for the target-server's connection
+        self.c2s_queued_data = []  # Data that was read from the Client, and needs to be sent to the  Server
+        self.s2c_queued_data = []  # Data that was read from the Server , and needs to be sent to the  client
+
+        # send data immediately to the client ... (Disable Nagle TCP algorithm)
+        self.c2p_stream.set_nodelay(True)
+        # Let us now when the client disconnects (callback on_c2p_close)
+        self.c2p_stream.set_close_callback(self.on_c2p_close)
+
+        self.s2c_stored_data = []  # data to store
+
+        # Here comes the caching...
+        # if we have cache - start writing it to the client
+        # and don't bother with "p2s (proxy->server) socket
+        # if we don't have cache - continue as usual
+        cached_data = g_cache.get(CACHE_KEY_NAME)  # no meaning for the key...
+        if cached_data:
+            cached_data_size = 0
+            for b in cached_data:
+                cached_data_size += len(b) if b else 0
+
+            logger.debug("using cache ({} bytes)".format(cached_data_size))
+            self.p2s_state = Session.State.CLOSED
+            self.p2s_stream = None
+            self.s2c_queued_data = cached_data[1:]  # close connection when done
+            self.s2c_queued_data.append(None)  # close connection when done
+            self.c2p_start_write(cached_data[0])
+        else:
+            logger.debug("no cache")
+            # Create the Proxy->Server socket and stream
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+
+            if self.proxy.server_ssl_options is not None:
+                # if the "server_ssl_options" where specified, it means that when we connect, we need to wrap with SSL
+                # so we need to use the SSLIOStream stream
+                self.p2s_stream = tornado.iostream.SSLIOStream(
+                    s, ssl_options=self.proxy.server_ssl_options)
+            else:
+                # use the standard IOStream stream
+                self.p2s_stream = tornado.iostream.IOStream(s)
+                # send data immediately to the server... (Disable Nagle TCP algorithm)
+                self.p2s_stream.set_nodelay(True)
+
+                # Let us know when the server disconnects (callback on_p2s_close)
+                self.p2s_stream.set_close_callback(self.on_p2s_close)
+                # P->S state is "connecting"
+                self.p2s_state = Session.State.CONNECTING
+                self.p2s_stream.connect(
+                    (proxy.target_server, proxy.target_port),
+                    self.on_p2s_done_connect)
+
+                # We can actually start reading immediately from the C->P socket
+                self.c2p_start_read()
+
+    @Session.logger_deco(LoggerOptions.LOG_READ_OP)
+    def on_p2s_done_read(self, data):
+        """got data from Server to Proxy .
+        if the client is still connected - append to the cached-stream
+        and send the data to the client
+        """
+        logger.debug("Adding data to cache (size {})".format(len(data)))
+        self.s2c_stored_data.append(data)
+        return super().on_p2s_done_read(data)
+
+    @Session.logger_deco(LoggerOptions.LOG_CLOSE_OP)
+    def on_p2s_close(self):
+        """
+        Server closed the connection.
+        We need to save all data to the cache,
+        update the state, and if the client closed as well - delete the session
+        """
+        if self.s2c_stored_data:
+            cached_data_size = 0
+            for b in self.s2c_stored_data:
+                cached_data_size += len(b) if b else 0
+
+            logger.debug("Saving data cache ({} bytes)".format(cached_data_size))
+            self.s2c_stored_data.append(None)
+            g_cache.set(CACHE_KEY_NAME, self.s2c_stored_data)
+            self.s2c_stored_data = None  # not required anymore
+
+        return super().on_p2s_close()
+
+
+class CachedSessionFactory(maproxy.session.SessionFactory):
+    """Session factory for cached-sessions"""
+
+    def new(self, *args, **kwargs):
+        """
+        The caller needs a Session objet (constructed with *args,**kwargs).
+        In this implementation we're simply creating a new object. you can enhance and create a pool or add logs..
+        """
+        return CachedSession(*args, **kwargs)
+
+    def delete(self, session):
+        """
+        Delete a session object
+        """
+        assert (isinstance(session, CachedSession))
+        del session

--- a/maproxy/session.py
+++ b/maproxy/session.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
-import tornado
+import logging
 import socket
+
+import tornado
+
 import maproxy.proxyserver
 
+logger = logging.getLogger(__name__)
 
 
 class Session(object):
@@ -35,219 +39,214 @@ class Session(object):
 
 
     """
+
     class LoggerOptions:
         """
         Logging options - which messages/notifications we would like to log...
         The logging is for development&maintenance. In production set all to False
         """
         # Log charactaristics
-        LOG_SESSION_ID=True         # for each log, add the session-id
+        LOG_SESSION_ID = True  # for each log, add the session-id
         # Log different operations
-        LOG_NEW_SESSION_OP=False
-        LOG_READ_OP=False
-        LOG_WRITE_OP=False
-        LOG_CLOSE_OP=False
-        LOG_CONNECT_OP=False
-        LOG_REMOVE_SESSION=False
-        
+        LOG_NEW_SESSION_OP = False
+        LOG_READ_OP = False
+        LOG_WRITE_OP = False
+        LOG_CLOSE_OP = False
+        LOG_CONNECT_OP = False
+        LOG_REMOVE_SESSION = False
+
     class State:
         """
         Each socket has a state.
         We will use the state to identify whether the connection is open or closed
         """
-        CLOSED,CONNECTING,CONNECTED=range(3)
-    
+        CLOSED, CONNECTING, CONNECTED = range(3)
+
     def __init__(self):
         pass
-    #def new_connection(self,stream : tornado.iostream.IOStream ,address,proxy):
-    def new_connection(self,stream ,address,proxy):
-            # First,validation
-            assert isinstance(proxy,maproxy.proxyserver.ProxyServer) 
-            assert isinstance(stream,tornado.iostream.IOStream)
-            
-            # Logging
-            self.logger_nesting_level=0         # logger_nesting_level is the current "nesting level"
-            if Session.LoggerOptions.LOG_NEW_SESSION_OP:
-                self.log("New Session")
 
-            
-            # Remember our "parent" ProxyServer 
-            self.proxy=proxy
+    # def new_connection(self,stream : tornado.iostream.IOStream ,address,proxy):
+    def new_connection(self, stream, address, proxy):
+        # First,validation
+        assert isinstance(proxy, maproxy.proxyserver.ProxyServer)
+        assert isinstance(stream, tornado.iostream.IOStream)
 
-            # R/W flags for each socket
-            # Using the flags, we can tell if we're waiting for I/O completion
-            # NOTE: the "c2p" and "p2s" prefixes are NOT the direction of the IO, 
-            #       they represent the SOCKETS :
-            #       c2p means the socket from the client to the proxy
-            #       p2s means the socket from the proxy to the server
-            self.c2p_reading=False  # whether we're reading from the client
-            self.c2p_writing=False  # whether we're writing to the client
-            self.p2s_writing=False  # whether we're writing to the server
-            self.p2s_reading=False  # whether we're reading from the server
+        # Logging
+        self.logger_nesting_level = 0  # logger_nesting_level is the current "nesting level"
+        if Session.LoggerOptions.LOG_NEW_SESSION_OP:
+            self.log("New Session")
 
-            # Init the Client->Proxy stream
-            self.c2p_stream=stream
-            self.c2p_address=address
-            # Client->Proxy  is connected
-            self.c2p_state=Session.State.CONNECTED
-            
-            # Here we will put incoming data while we're still waiting for the target-server's connection
-            self.c2s_queued_data=[] # Data that was read from the Client, and needs to be sent to the  Server
-            self.s2c_queued_data=[] # Data that was read from the Server , and needs to be sent to the  client
+        # Remember our "parent" ProxyServer
+        self.proxy = proxy
 
-            # send data immediately to the client ... (Disable Nagle TCP algorithm)
-            self.c2p_stream.set_nodelay(True)
-            # Let us now when the client disconnects (callback on_c2p_close)
-            self.c2p_stream.set_close_callback( self.on_c2p_close)
+        # R/W flags for each socket
+        # Using the flags, we can tell if we're waiting for I/O completion
+        # NOTE: the "c2p" and "p2s" prefixes are NOT the direction of the IO,
+        #       they represent the SOCKETS :
+        #       c2p means the socket from the client to the proxy
+        #       p2s means the socket from the proxy to the server
+        self.c2p_reading = False  # whether we're reading from the client
+        self.c2p_writing = False  # whether we're writing to the client
+        self.p2s_writing = False  # whether we're writing to the server
+        self.p2s_reading = False  # whether we're reading from the server
 
-            # Create the Proxy->Server socket and stream
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-            
-            if self.proxy.server_ssl_options is not None:
-                # if the "server_ssl_options" where specified, it means that when we connect, we need to wrap with SSL
-                # so we need to use the SSLIOStream stream
-                self.p2s_stream = tornado.iostream.SSLIOStream(s,ssl_options=self.proxy.server_ssl_options)
-            else:
-                # use the standard IOStream stream
-                self.p2s_stream = tornado.iostream.IOStream(s)
-            # send data immediately to the server... (Disable Nagle TCP algorithm)
-            self.p2s_stream.set_nodelay(True)
-            
-            # Let us now when the server disconnects (callback on_p2s_close)
-            self.p2s_stream.set_close_callback(  self.on_p2s_close )
-            # P->S state is "connecting"
-            self.p2s_state=self.p2s_state=Session.State.CONNECTING
-            self.p2s_stream.connect(( proxy.target_server, proxy.target_port),  self.on_p2s_done_connect )
-            
+        # Init the Client->Proxy stream
+        self.c2p_stream = stream
+        self.c2p_address = address
+        # Client->Proxy  is connected
+        self.c2p_state = Session.State.CONNECTED
 
-            # We can actually start reading immediatelly from the C->P socket
-            self.c2p_start_read()
-    
+        # Here we will put incoming data while we're still waiting for the target-server's connection
+        self.c2s_queued_data = []  # Data that was read from the Client, and needs to be sent to the  Server
+        self.s2c_queued_data = []  # Data that was read from the Server , and needs to be sent to the  client
+
+        # send data immediately to the client ... (Disable Nagle TCP algorithm)
+        self.c2p_stream.set_nodelay(True)
+        # Let us now when the client disconnects (callback on_c2p_close)
+        self.c2p_stream.set_close_callback(self.on_c2p_close)
+
+        # Create the Proxy->Server socket and stream
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+
+        if self.proxy.server_ssl_options is not None:
+            # if the "server_ssl_options" where specified, it means that when we connect, we need to wrap with SSL
+            # so we need to use the SSLIOStream stream
+            self.p2s_stream = tornado.iostream.SSLIOStream(
+                s, ssl_options=self.proxy.server_ssl_options)
+        else:
+            # use the standard IOStream stream
+            self.p2s_stream = tornado.iostream.IOStream(s)
+        # send data immediately to the server... (Disable Nagle TCP algorithm)
+        self.p2s_stream.set_nodelay(True)
+
+        # Let us now when the server disconnects (callback on_p2s_close)
+        self.p2s_stream.set_close_callback(self.on_p2s_close)
+        # P->S state is "connecting"
+        self.p2s_state = self.p2s_state = Session.State.CONNECTING
+        self.p2s_stream.connect((proxy.target_server, proxy.target_port),
+                                self.on_p2s_done_connect)
+
+        # We can actually start reading immediately from the C->P socket
+        self.c2p_start_read()
+
     # Each member-function can call this method to log data (currently to screen)
-    def log(self,msg):
-        prefix=str(id(self))+":" if Session.LoggerOptions.LOG_SESSION_ID else ""
-        prefix+=self.logger_nesting_level*" "*4
-        logging.debug(prefix + msg)
-        
-        
+    def log(self, msg):
+        prefix = str(
+            id(self)) + ":" if Session.LoggerOptions.LOG_SESSION_ID else ""
+        prefix += self.logger_nesting_level * " " * 4
+        logger.debug(prefix + msg)
 
     #  Logging decorator (enter/exit)
-    def logger(enabled=True):
+    def logger_deco(enabled=True):
         """
         We use this decorator to wrap functions and log the input/ouput of each function
         Since this decorator accepts a parameter, it must return an "inner" decorator....(Python stuff)
         """
+
         def inner_decorator(func):
-            
-        
-            def log_wrapper(self,*args,**kwargs):
+            def log_wrapper(self, *args, **kwargs):
+                msg = "%s (%s,%s)" % (func.__name__, args, kwargs)
 
-                msg="%s (%s,%s)" % (func.__name__,args,kwargs)
-
-            
                 self.log(msg)
-                self.logger_nesting_level+=1
-                r=func(self,*args,**kwargs)
-                self.logger_nesting_level-=1
-                self.log("%s -> %s" % (msg,str(r)) )
+                self.logger_nesting_level += 1
+                r = func(self, *args, **kwargs)
+                self.logger_nesting_level -= 1
+                self.log("%s -> %s" % (msg, str(r)))
                 return r
+
             return log_wrapper if enabled else func
-            
 
         return inner_decorator
 
-        
-        
     ################
     ## Start Read ##
     ################
-    @logger(LoggerOptions.LOG_READ_OP)
+    @logger_deco(LoggerOptions.LOG_READ_OP)
     def c2p_start_read(self):
         """
         Start read from client
         """
-        assert( not self.c2p_reading)
-        self.c2p_reading=True
+        assert (not self.c2p_reading)
+        self.c2p_reading = True
         try:
-            self.c2p_stream.read_until_close(lambda x: None,self.on_c2p_done_read)
+            self.c2p_stream.read_until_close(lambda x: None,
+                                             self.on_c2p_done_read)
         except tornado.iostream.StreamClosedError:
-            self.c2p_reading=False
+            self.c2p_reading = False
 
-    @logger(LoggerOptions.LOG_READ_OP)
+    @logger_deco(LoggerOptions.LOG_READ_OP)
     def p2s_start_read(self):
         """
         Start read from server
         """
-        assert( not self.p2s_reading)
-        self.p2s_reading=True
+        assert (not self.p2s_reading)
+        self.p2s_reading = True
         try:
-            self.p2s_stream.read_until_close(lambda x:None,self.on_p2s_done_read)
-        except tornado.iostream.StreamClosedError:    
-            self.p2s_reading=False
-    
-    
+            self.p2s_stream.read_until_close(lambda x: None,
+                                             self.on_p2s_done_read)
+        except tornado.iostream.StreamClosedError:
+            self.p2s_reading = False
+
     ##############################
     ## Read Completion Routines ##
     ##############################
-    @logger(LoggerOptions.LOG_READ_OP)
-    def on_c2p_done_read(self,data):
+    @logger_deco(LoggerOptions.LOG_READ_OP)
+    def on_c2p_done_read(self, data):
         # # We got data from the client (C->P ) . Send data to the server
-        assert(self.c2p_reading)
-        assert(data)
+        assert (self.c2p_reading)
+        assert (data)
         self.p2s_start_write(data)
-        
-        
-    @logger(LoggerOptions.LOG_READ_OP)
-    def on_p2s_done_read(self,data):
-        # got data from Server to Proxy . if the client is still connected - send the data to the client
-        assert( self.p2s_reading)
-        assert(data)
-        self.c2p_start_write(data)
 
+    @logger_deco(LoggerOptions.LOG_READ_OP)
+    def on_p2s_done_read(self, data):
+        # got data from Server to Proxy . if the client is still connected - send the data to the client
+        assert (self.p2s_reading)
+        assert (data)
+        self.c2p_start_write(data)
 
     #####################
     ## Write to stream ##
     #####################
-    @logger(LoggerOptions.LOG_WRITE_OP)
-    def _c2p_io_write(self,data):
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
+    def _c2p_io_write(self, data):
         if data is None:
             # None means (gracefully) close-socket  (a "close request" that was queued...)
-            self.c2p_state=Session.State.CLOSED
+            self.c2p_state = Session.State.CLOSED
             try:
                 self.c2p_stream.close()
             except tornado.iostream.StreamClosedError:
-                self.c2p_writing=False
+                self.c2p_writing = False
         else:
-            self.c2p_writing=True
+            self.c2p_writing = True
             try:
-                self.c2p_stream.write(data,callback=self.on_c2p_done_write)
+                self.c2p_stream.write(data, callback=self.on_c2p_done_write)
             except tornado.iostream.StreamClosedError:
                 # Cancel the write, we will get on_close instead...
-                self.c2p_writing=False
-    @logger(LoggerOptions.LOG_WRITE_OP)
-    def _p2s_io_write(self,data):
+                self.c2p_writing = False
+
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
+    def _p2s_io_write(self, data):
         if data is None:
             # None means (gracefully) close-socket  (a "close request" that was queued...)
-            self.p2s_state=Session.State.CLOSED
+            self.p2s_state = Session.State.CLOSED
             try:
                 self.p2s_stream.close()
             except tornado.iostream.StreamClosedError:
                 # Cancel the write. we will get on_close instead
-                self.p2s_writing=False
+                self.p2s_writing = False
         else:
-            self.p2s_writing=True
+            self.p2s_writing = True
             try:
-                self.p2s_stream.write(data,callback=self.on_p2s_done_write)
+                self.p2s_stream.write(data, callback=self.on_p2s_done_write)
             except tornado.iostream.StreamClosedError:
                 # Cancel the write. we will get on_close instead
-                self.p2s_writing=False
-
+                self.p2s_writing = False
 
     #################
     ## Start Write ##
     #################
-    @logger(LoggerOptions.LOG_WRITE_OP)
-    def c2p_start_write(self,data):
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
+    def c2p_start_write(self, data):
         """
         Write to client.if there's a pending write-operation, add it to the S->C (s2c) queue
         """
@@ -256,31 +255,33 @@ class Session(object):
 
         if not self.c2p_writing:
             # If we're not currently writing
-            assert( not self.s2c_queued_data ) # we expect the  queue to be empty
-            
+            #assert (
+            #    not self.s2c_queued_data)  # we expect the  queue to be empty
+
             # Start the "real" write I/O operation
             self._c2p_io_write(data)
         else:
             # Just add to the queue
             self.s2c_queued_data.append(data)
-    
-    @logger(LoggerOptions.LOG_WRITE_OP)
-    def p2s_start_write(self,data):
+
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
+    def p2s_start_write(self, data):
         """
         Write to the server.
         If not connected yet - queue the data
         If there's a pending write-operation , add it to the C->S (c2s) queue
         """
-        
+
         # If still connecting to the server - queue the data...
-        if self.p2s_state == Session.State.CONNECTING:  
-            self.c2s_queued_data.append(data)   # TODO: is it better here to append (to list) or concatenate data (to buffer) ?
+        if self.p2s_state == Session.State.CONNECTING:
+            self.c2s_queued_data.append(
+                data)  # TODO: is it better here to append (to list) or concatenate data (to buffer) ?
             return
         # If not connected - do nothing
-        if self.p2s_state == Session.State.CLOSED:  
+        if self.p2s_state == Session.State.CLOSED:
             return
-        assert(self.p2s_state == Session.State.CONNECTED)
-        
+        assert (self.p2s_state == Session.State.CONNECTED)
+
         if not self.p2s_writing:
             # Start the "real" write I/O operation
             self._p2s_io_write(data)
@@ -288,45 +289,40 @@ class Session(object):
             # Just add to the queue
             self.c2s_queued_data.append(data)
 
-    
     ##############################
     ## Write Competion Routines ##
     ##############################
-    @logger(LoggerOptions.LOG_WRITE_OP)
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
     def on_c2p_done_write(self):
         """
         A start_write C->P  (write to client) is done .
         if there is queued-data to send - send it
         """
-        assert(self.c2p_writing)
+        assert (self.c2p_writing)
         if self.s2c_queued_data:
             # more data in the queue, write next item as well..
-            self._c2p_io_write( self.s2c_queued_data.pop(0))
+            self._c2p_io_write(self.s2c_queued_data.pop(0))
             return
-        self.c2p_writing=False
-        
-    
-        
-    @logger(LoggerOptions.LOG_WRITE_OP)
+        self.c2p_writing = False
+
+    @logger_deco(LoggerOptions.LOG_WRITE_OP)
     def on_p2s_done_write(self):
         """
         A start_write P->S  (write to server) is done .
         if there is queued-data to send - send it
         """
-        assert(self.p2s_writing)
+        assert (self.p2s_writing)
         if self.c2s_queued_data:
             # more data in the queue, write next item as well..
-            self._p2s_io_write( self.c2s_queued_data.pop(0))
+            self._p2s_io_write(self.c2s_queued_data.pop(0))
             return
-        self.p2s_writing=False
-        
-
+        self.p2s_writing = False
 
     ######################
     ## Close Connection ##
     ######################
-    @logger(LoggerOptions.LOG_CLOSE_OP)
-    def c2p_start_close(self,gracefully=True):
+    @logger_deco(LoggerOptions.LOG_CLOSE_OP)
+    def c2p_start_close(self, gracefully=True):
         """
         Close c->p connection
         if gracefully is True then we simply add None to the queue, and start a write-operation
@@ -343,14 +339,13 @@ class Session(object):
             return
 
         self.c2p_state = Session.State.CLOSED
-        self.s2c_queued_data=[]
+        self.s2c_queued_data = []
         self.c2p_stream.close()
         if self.p2s_state == Session.State.CLOSED:
             self.remove_session()
-            
-            
-    @logger(LoggerOptions.LOG_CLOSE_OP)
-    def p2s_start_close(self,gracefully=True):
+
+    @logger_deco(LoggerOptions.LOG_CLOSE_OP)
+    def p2s_start_close(self, gracefully=True):
         """
         Close p->s connection
         if gracefully is True then we simply add None to the queue, and start a write-operation
@@ -367,13 +362,12 @@ class Session(object):
             return
 
         self.p2s_state = Session.State.CLOSED
-        self.c2s_queued_data=[]
+        self.c2s_queued_data = []
         self.p2s_stream.close()
         if self.c2p_state == Session.State.CLOSED:
             self.remove_session()
-        
 
-    @logger(LoggerOptions.LOG_CLOSE_OP)
+    @logger_deco(LoggerOptions.LOG_CLOSE_OP)
     def on_c2p_close(self):
         """
         Client closed the connection.
@@ -382,47 +376,47 @@ class Session(object):
         2. if there's no more data to the server (c2s_queued_data is empty) - we can close the p2s connection
         3. if p2s already closed - we can remove the session
         """
-        self.c2p_state=Session.State.CLOSED
+        self.c2p_state = Session.State.CLOSED
         if self.p2s_state == Session.State.CLOSED:
             self.remove_session()
         else:
             self.p2s_start_close(gracefully=True)
-            
 
-    @logger(LoggerOptions.LOG_CLOSE_OP)
+    @logger_deco(LoggerOptions.LOG_CLOSE_OP)
     def on_p2s_close(self):
         """
         Server closed the connection.
-        We need to update the satte, and if the client closed as well - delete the session
+        We need to update the state, and if the client closed as well - delete the session
         """
-        self.p2s_state=Session.State.CLOSED
+        self.p2s_state = Session.State.CLOSED
         if self.c2p_state == Session.State.CLOSED:
             self.remove_session()
         else:
             self.c2p_start_close(gracefully=True)
-        
+
     ########################
     ## Connect-Completion ##
     ########################
-    @logger(LoggerOptions.LOG_CONNECT_OP)
+    @logger_deco(LoggerOptions.LOG_CONNECT_OP)
     def on_p2s_done_connect(self):
-        assert(self.p2s_state==Session.State.CONNECTING)
-        self.p2s_state=Session.State.CONNECTED
+        assert (self.p2s_state == Session.State.CONNECTING)
+        self.p2s_state = Session.State.CONNECTED
         # Start reading from the socket
         self.p2s_start_read()
-        assert(not self.p2s_writing)    # As expect no current write-operation ...
-        
+        assert (
+            not self.p2s_writing)  # As expect no current write-operation ...
+
         # If we have pending-data to write, start writing...
         if self.c2s_queued_data:
             # TRICKY: get thte frst item , and write it...
             # this is tricky since the "start-write" will 
             # write this item even if there are queued-items... (since self.p2s_writing=False)
-            self.p2s_start_write( self.c2s_queued_data.pop(0)  )
-    
+            self.p2s_start_write(self.c2s_queued_data.pop(0))
+
     ###########
     ## UTILS ##
     ###########
-    @logger(LoggerOptions.LOG_REMOVE_SESSION)
+    @logger_deco(LoggerOptions.LOG_REMOVE_SESSION)
     def remove_session(self):
         self.proxy.remove_session(self)
 
@@ -431,19 +425,20 @@ class SessionFactory(object):
     """
     This is  the default session-factory. it simply returns a "Session" object
     """
+
     def __init__(self):
         pass
-        
-    def new(self,*args,**kwargs):
+
+    def new(self, *args, **kwargs):
         """
         The caller needs a Session objet (constructed with *args,**kwargs).
         In this implementation we're simply creating a new object. you can enhance and create a pool or add logs..
         """
-        return Session(*args,**kwargs)
-    def delete(self,session):
+        return Session(*args, **kwargs)
+
+    def delete(self, session):
         """
         Delete a session object
         """
-        assert( isinstance(session,Session))
+        assert (isinstance(session, Session))
         del session
-        

--- a/run.py
+++ b/run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import tornado.ioloop
+import maproxy.proxyserver
+import maproxy.cachedsession
+
+server = maproxy.proxyserver.ProxyServer(
+    "speedtest.tele2.net",80,
+    session_factory=maproxy.cachedsession.CachedSessionFactory()
+)
+server.listen(5000,address="0.0.0.0")
+tornado.ioloop.IOLoop.instance().start()
+


### PR DESCRIPTION
Add simple caching (in memory, not redis/memcache) .

    When we get a new connection - if we have "cached data" - return the cached
    data (and don't even bother opening a socket to the server).

    If we don't have cached data - operate just like standard session however
    keep the data from the server in a cache. Note that we're storing in the
    cache only when the connection is closed (to avoid partial data) !!!!


